### PR TITLE
feat: consumed (and exposed "via API") type

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,10 +8,10 @@ jobs:
     name: OTP ${{matrix.otp}}
     strategy:
       matrix:
-        otp: ["23.2", "24.0"]
+        otp: ["23.2", "24.0", "25", "26"]
     steps:
     - uses: actions/checkout@v2.0.0
-    - uses: gleam-lang/setup-erlang@v1.1.2
+    - uses: erlef/setup-beam@v1.16.0
       with:
         otp-version: ${{matrix.otp}}
     - name: Compile

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4,11 +4,11 @@ on: [push]
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: OTP ${{matrix.otp}}
     strategy:
       matrix:
-        otp: ["23", "24", "25", "26"]
+        otp: ["24", "25", "26"]
         rebar3: ["3.22.1"]
     steps:
     - uses: actions/checkout@v2.0.0

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9,11 +9,13 @@ jobs:
     strategy:
       matrix:
         otp: ["23.2", "24.0", "25", "26"]
+        rebar3: ["3.22.1"]
     steps:
     - uses: actions/checkout@v2.0.0
     - uses: erlef/setup-beam@v1.16.0
       with:
         otp-version: ${{matrix.otp}}
+        rebar3-version: ${{matrix.rebar3}}
     - name: Compile
       run: make compile
     - name: Run dialyzer

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,7 +8,7 @@ jobs:
     name: OTP ${{matrix.otp}}
     strategy:
       matrix:
-        otp: ["23.2", "24.0", "25", "26"]
+        otp: ["23", "24", "25", "26"]
         rebar3: ["3.22.1"]
     steps:
     - uses: actions/checkout@v2.0.0

--- a/src/eon_type.erl
+++ b/src/eon_type.erl
@@ -33,6 +33,7 @@
 -type decl(A)    :: lit(A, spec()).    %declaration
 -type spec()     :: type()             %single alternative
                   | sum().             %multiple alternatives
+-export_type([spec/0]).
 -type type()     :: cb()               %eon_type_*
                   | {cb(), lit(_, _)}. %type args
 -type sum()      :: [spec()].          %left-to-right


### PR DESCRIPTION
## Motivation

Used by [`kivra_core`](https://github.com/kivra/kivra_core/blob/9b9cdd9cca458374047c2de20ac7cac1e13a9785/src/rest/rest_handler.erl#L94).

## Further considerations

I up'ed CI and results are promising. Now going after 24, 25, and 26 😄 