### PR TITLE
Fix type spec. for `-type object(A, B)`

### DIFF
--- a/src/eon.erl
+++ b/src/eon.erl
@@ -79,7 +79,8 @@
 -type object(A, B)  :: orddict:orddict()
                      | kv_list(A, B)
                      | literal(A, B)
-                     | dict:dict().
+                     | dict:dict()
+                     | map(A, B).
 
 -type literal(A, B) :: [A | B].
 -type deep_key()    :: binary() | list().


### PR DESCRIPTION
As per

```erlang
1> eon:dget(#{<<"a">> => 2}, <<"a">>).
{ok,2}
```

and

```erlang
2> eon:dget(#{<<"a">> => [{<<"a">>, 2}]}, <<"a.a">>).
{ok,2}
```